### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ services:
 jdk:
   - openjdk11
 install:
-  - travis_retry ./gradlew --info dependencies --refresh-dependencies
+  - ./gradlew --info dependencies --refresh-dependencies
 script:
   - ./gradlew build --stacktrace --info
 after_success:
   - bash <(curl -s https://codecov.io/bash)
+
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
